### PR TITLE
Track and delete xcancel alerts

### DIFF
--- a/archivebot.py
+++ b/archivebot.py
@@ -13,15 +13,13 @@ from openai import OpenAI
 from ai_context import format_messages_for_prompt, get_ai_context_scope, is_engage_request
 from utils import db_connect, migrate_db
 from url_cleaner import UrlCleaner
+from xcancel import build_xcancel_response_text
 from sferait_context import (
     SFERAIT_SYSTEM_PROMPT,
     get_recent_messages,
     search_archive,
     build_enhanced_prompt
 )
-
-# Pre-compiled regex patterns
-_X_COM_PATTERN = re.compile(r'^https?://(?:www\.)?x\.com/(.+)$', re.IGNORECASE)
 
 # Admin users che possono eseguire comandi privilegiati (stessa lista di flask_app.py)
 ADMIN_USERS = [
@@ -534,44 +532,145 @@ def normalize_url(url):
         return url
 
 
+def save_xcancel_alert(parent_ts, alert_ts, channel, alert_text):
+    """Salva il riferimento all'alert xcancel per cancellarlo quando serve."""
+    if not parent_ts or not alert_ts or not channel:
+        return
+
+    conn, cursor = db_connect(database_path)
+    try:
+        cursor.execute(
+            """
+            INSERT OR REPLACE INTO xcancel_alerts
+            (parent_message_ts, alert_message_ts, channel, alert_text)
+            VALUES (?, ?, ?, ?)
+            """,
+            (parent_ts, alert_ts, channel, alert_text),
+        )
+        conn.commit()
+        logger.debug(f"Saved xcancel alert reference: parent_ts={parent_ts}, alert_ts={alert_ts}")
+    except Exception as e:
+        logger.error(f"Error saving xcancel alert reference: {e}")
+        conn.rollback()
+    finally:
+        conn.close()
+
+
+def delete_xcancel_alert(parent_ts, channel=None):
+    """Cancella da Slack e dal DB l'alert xcancel associato a un messaggio."""
+    if not parent_ts:
+        return False
+
+    conn, cursor = db_connect(database_path)
+    deleted_any = False
+    try:
+        if channel:
+            cursor.execute(
+                """
+                SELECT alert_message_ts, channel
+                FROM xcancel_alerts
+                WHERE parent_message_ts = ? AND channel = ?
+                """,
+                (parent_ts, channel),
+            )
+        else:
+            cursor.execute(
+                """
+                SELECT alert_message_ts, channel
+                FROM xcancel_alerts
+                WHERE parent_message_ts = ?
+                """,
+                (parent_ts,),
+            )
+
+        alerts = cursor.fetchall()
+
+        for alert_ts, alert_channel in alerts:
+            try:
+                app.client.chat_delete(channel=alert_channel, ts=alert_ts)
+                deleted_any = True
+                logger.info(
+                    f"XCANCEL_ALERT_DELETED: Deleted orphaned xcancel alert: "
+                    f"alert_ts='{alert_ts}' channel='{alert_channel}' parent_ts='{parent_ts}'"
+                )
+            except Exception as e:
+                logger.warning(f"Could not delete xcancel alert {alert_ts}: {e}")
+
+        if alerts:
+            if channel:
+                cursor.execute(
+                    "DELETE FROM xcancel_alerts WHERE parent_message_ts = ? AND channel = ?",
+                    (parent_ts, channel),
+                )
+            else:
+                cursor.execute("DELETE FROM xcancel_alerts WHERE parent_message_ts = ?", (parent_ts,))
+            conn.commit()
+
+    except Exception as e:
+        logger.error(f"Error deleting xcancel alert for parent_ts={parent_ts}: {e}")
+        conn.rollback()
+    finally:
+        conn.close()
+
+    return deleted_any
+
+
+def get_xcancel_alert_text(parent_ts, channel):
+    """Restituisce il testo dell'alert xcancel tracciato, se presente."""
+    if not parent_ts or not channel:
+        return None
+
+    conn, cursor = db_connect(database_path)
+    try:
+        cursor.execute(
+            """
+            SELECT alert_text
+            FROM xcancel_alerts
+            WHERE parent_message_ts = ? AND channel = ?
+            """,
+            (parent_ts, channel),
+        )
+        row = cursor.fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
 def post_xcancel_alternatives(message, say):
     """Se il messaggio contiene link a x.com, posta le alternative xcancel.com nel thread."""
-    text = message.get("text", "")
-    if not text:
+    response_text = build_xcancel_response_text(message.get("text", ""))
+    if not response_text:
         return
-    
-    urls = extract_urls(text)
-    if not urls:
-        return
-    
-    xcancel_links = set()  # Use set to deduplicate
-    for url in urls:
-        match = _X_COM_PATTERN.match(url)
-        if match:
-            path = match.group(1)
-            xcancel_url = f"https://xcancel.com/{path}"
-            # Controlla che l'utente non abbia già postato il link xcancel
-            if xcancel_url.lower() not in text.lower():
-                xcancel_links.add(xcancel_url)
-    
-    if not xcancel_links:
-        return
-    
-    # Costruisci il messaggio
-    xcancel_list = list(xcancel_links)
-    if len(xcancel_list) == 1:
-        response_text = f"🔗 Link senza Shitler: {xcancel_list[0]}"
-    else:
-        links_formatted = "\n".join(f"• {link}" for link in xcancel_list)
-        response_text = f"🔗 Link senza Shitler:\n{links_formatted}"
-    
-    # Posta nel thread (usa thread_ts se esiste, altrimenti ts del messaggio)
+
+    parent_ts = message.get("ts")
     thread_ts = message.get("thread_ts", message.get("ts"))
     try:
-        say(text=response_text, thread_ts=thread_ts)
-        logger.info(f"Posted xcancel alternatives for {len(xcancel_links)} x.com link(s)")
+        result = say(text=response_text, thread_ts=thread_ts)
+        alert_ts = result.get("ts") if result else None
+        if alert_ts:
+            save_xcancel_alert(parent_ts, alert_ts, message.get("channel"), response_text)
+        logger.info("Posted xcancel alternatives")
     except Exception as e:
         logger.error(f"Error posting xcancel alternative: {e}")
+
+
+def sync_xcancel_alternatives_for_message(message, say):
+    """Allinea l'alert xcancel quando un messaggio viene modificato."""
+    parent_ts = message.get("ts")
+    channel = message.get("channel")
+    expected_text = build_xcancel_response_text(message.get("text", ""))
+    existing_text = get_xcancel_alert_text(parent_ts, channel)
+
+    if not expected_text:
+        delete_xcancel_alert(parent_ts, channel)
+        return
+
+    if existing_text == expected_text:
+        logger.debug(f"XCANCEL_ALERT_UNCHANGED: parent_ts={parent_ts} channel={channel}")
+        return
+
+    delete_xcancel_alert(parent_ts, channel)
+    post_xcancel_alternatives(message, say)
 
 
 def check_and_store_links(message, permalink_dict, say):
@@ -2212,8 +2311,10 @@ def handle_message_thread_broadcast(event, say):
 
 
 @app.event({"type": "message", "subtype": "message_changed"})
-def handle_message_changed(event):
+def handle_message_changed(event, say):
     message = event.get("message", {})
+    if "channel" not in message and event.get("channel"):
+        message["channel"] = event["channel"]
 
     # Slack a volte invia message_changed quando un messaggio viene cancellato
     # In questo caso, il messaggio ha subtype "tombstone" o non ha "text"
@@ -2234,6 +2335,8 @@ def handle_message_changed(event):
         conn.commit()
     finally:
         conn.close()
+
+    sync_xcancel_alternatives_for_message(message, say)
 
 
 def handle_message_deleted_logic(deleted_ts, channel):
@@ -2309,6 +2412,8 @@ def handle_message_deleted_logic(deleted_ts, channel):
             # Rimuovi dalla tabella duplicate_alerts
             cursor.execute("DELETE FROM duplicate_alerts WHERE parent_message_ts = ?", (deleted_ts,))
             conn.commit()
+
+        delete_xcancel_alert(deleted_ts, channel)
 
     except Exception as e:
         logger.error(f"Error handling message deletion for ts={deleted_ts}: {e}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+import os
+import sqlite3
+import sys
+
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from utils import migrate_db
+
+
+def test_migrate_db_creates_xcancel_alerts_table():
+    conn = sqlite3.connect(":memory:")
+    cursor = conn.cursor()
+
+    migrate_db(conn, cursor)
+
+    columns = {
+        row[1]
+        for row in cursor.execute("PRAGMA table_info(xcancel_alerts)").fetchall()
+    }
+    assert columns == {
+        "parent_message_ts",
+        "alert_message_ts",
+        "channel",
+        "alert_text",
+    }

--- a/tests/test_xcancel.py
+++ b/tests/test_xcancel.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from xcancel import build_xcancel_response_text
+
+
+def test_build_xcancel_response_for_single_x_link():
+    text = "Guarda https://x.com/someone/status/123"
+
+    assert build_xcancel_response_text(text) == (
+        "🔗 Link senza Shitler: https://xcancel.com/someone/status/123"
+    )
+
+
+def test_build_xcancel_response_deduplicates_and_sorts_links():
+    text = (
+        "https://x.com/b/status/2 "
+        "https://x.com/a/status/1 "
+        "https://x.com/b/status/2"
+    )
+
+    assert build_xcancel_response_text(text) == (
+        "🔗 Link senza Shitler:\n"
+        "• https://xcancel.com/a/status/1\n"
+        "• https://xcancel.com/b/status/2"
+    )
+
+
+def test_build_xcancel_response_ignores_existing_xcancel_link():
+    text = "https://x.com/someone/status/123 https://xcancel.com/someone/status/123"
+
+    assert build_xcancel_response_text(text) is None
+
+
+def test_build_xcancel_response_ignores_non_x_links():
+    assert build_xcancel_response_text("https://example.com/post") is None

--- a/utils.py
+++ b/utils.py
@@ -309,6 +309,35 @@ def migrate_db(conn, cursor):
     except:
         pass
 
+    # Tabella per tracciare gli alert xcancel (per cancellarli se il messaggio parent viene cancellato/modificato)
+    try:
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS xcancel_alerts (
+                parent_message_ts TEXT NOT NULL,
+                alert_message_ts TEXT NOT NULL,
+                channel TEXT NOT NULL,
+                alert_text TEXT NOT NULL DEFAULT '',
+                PRIMARY KEY (parent_message_ts, channel)
+            )
+        """
+        )
+        conn.commit()
+    except:
+        pass
+
+    # Aggiungi il testo atteso agli alert xcancel esistenti per gestire update idempotenti.
+    try:
+        cursor.execute(
+            """
+            ALTER TABLE xcancel_alerts
+            ADD COLUMN alert_text TEXT NOT NULL DEFAULT ''
+            """
+        )
+        conn.commit()
+    except:
+        pass
+
     # Tabella per tracciare i thread su #trash in cui il bot si è auto-ingaggiato
     try:
         cursor.execute(

--- a/xcancel.py
+++ b/xcancel.py
@@ -1,0 +1,40 @@
+import re
+
+
+_X_COM_PATTERN = re.compile(r"^https?://(?:www\.)?x\.com/(.+)$", re.IGNORECASE)
+
+
+def extract_urls(text):
+    """Estrae tutti gli URL HTTP/HTTPS da un testo."""
+    url_pattern = r'https?://[^\s<>":{}|\\^`\[\]]+'
+    urls = re.findall(url_pattern, text, flags=re.IGNORECASE)
+    return [url.rstrip(".,;:!?") for url in urls]
+
+
+def build_xcancel_response_text(text):
+    """Costruisce la risposta xcancel attesa per un testo Slack."""
+    if not text:
+        return None
+
+    urls = extract_urls(text)
+    if not urls:
+        return None
+
+    xcancel_links = set()
+    for url in urls:
+        match = _X_COM_PATTERN.match(url)
+        if match:
+            path = match.group(1)
+            xcancel_url = f"https://xcancel.com/{path}"
+            if xcancel_url.lower() not in text.lower():
+                xcancel_links.add(xcancel_url)
+
+    if not xcancel_links:
+        return None
+
+    xcancel_list = sorted(xcancel_links)
+    if len(xcancel_list) == 1:
+        return f"🔗 Link senza Shitler: {xcancel_list[0]}"
+
+    links_formatted = "\n".join(f"• {link}" for link in xcancel_list)
+    return f"🔗 Link senza Shitler:\n{links_formatted}"


### PR DESCRIPTION
## Summary

Fixes orphaned xcancel replies when an original X link message is deleted or edited.

## Root Cause

The bot posted xcancel alternatives with `say(...)` but did not store the returned Slack message timestamp. Deletion cleanup only tracked duplicate-link alerts, so xcancel replies were left behind.

## Changes

- Add an `xcancel_alerts` table to track parent message timestamps, bot reply timestamps, channels, and expected alert text.
- Store xcancel reply timestamps when xcancel alternatives are posted.
- Delete tracked xcancel replies when the parent message is deleted.
- Synchronize xcancel replies on message edits:
  - delete when X links are removed
  - keep unchanged replies
  - replace stale replies when X links change
- Move xcancel response construction into a small testable helper module.

## Validation

- `pytest tests` passed: 45 tests.
- `py_compile` passed for touched files.
- `git diff --check` passed.

Note: full `pytest` discovery also picks up `utilities/test_embeddings.py`, which requires `sentence_transformers`; that dependency was not installed in the temporary lightweight test environment.