### PR TITLE
[codex] add hot path database indexes

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,3 +26,26 @@ def test_migrate_db_creates_xcancel_alerts_table():
         "channel",
         "alert_text",
     }
+
+
+def test_migrate_db_creates_hot_path_indexes():
+    conn = sqlite3.connect(":memory:")
+    cursor = conn.cursor()
+
+    migrate_db(conn, cursor)
+
+    indexes = {
+        row[1]
+        for row in cursor.execute(
+            "SELECT type, name FROM sqlite_master WHERE type = 'index'"
+        ).fetchall()
+    }
+
+    assert {
+        "idx_messages_thread_channel",
+        "idx_messages_user",
+        "idx_messages_timestamp",
+        "idx_messages_embedded_timestamp",
+        "idx_members_channel_user",
+        "idx_posted_links_normalized_posted_date",
+    }.issubset(indexes)

--- a/utils.py
+++ b/utils.py
@@ -98,6 +98,37 @@ def migrate_db(conn, cursor):
     except:
         pass
 
+    # Index hot read/write paths. Keep this set small: these match existing
+    # filters and joins used by archive browsing, search, stats, and link checks.
+    for index_sql in [
+        """
+        CREATE INDEX IF NOT EXISTS idx_messages_thread_channel
+        ON messages(thread_ts, channel)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_messages_user
+        ON messages(user)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_messages_timestamp
+        ON messages(timestamp)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_messages_embedded_timestamp
+        ON messages(timestamp)
+        WHERE embeddings IS NOT NULL
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_members_channel_user
+        ON members(channel, user)
+        """,
+    ]:
+        try:
+            cursor.execute(index_sql)
+            conn.commit()
+        except:
+            pass
+
     # digests table
     try:
         cursor.execute(
@@ -303,6 +334,17 @@ def migrate_db(conn, cursor):
                 channel TEXT NOT NULL,
                 PRIMARY KEY (parent_message_ts, channel)
             )
+        """
+        )
+        conn.commit()
+    except:
+        pass
+
+    try:
+        cursor.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_posted_links_normalized_posted_date
+            ON posted_links(normalized_url, posted_date)
         """
         )
         conn.commit()


### PR DESCRIPTION
## Summary
- add a small set of SQLite indexes for existing archive hot paths
- cover thread lookup, timestamp lookup, user rewrite, embedded-row scans, member channel lookup, and duplicate-link recency checks
- add migration coverage that asserts the expected indexes are created

## Why
Several common paths currently fall back to table scans as the archive grows:
- loading thread/message records by `timestamp` or `thread_ts`
- rewriting all archived messages for a user during opt-out
- scanning embedded messages for `/searchEmbeddings`
- looking up duplicate links by normalized URL and recency
- resolving members by channel

I intentionally did not add a `messages(channel, timestamp)` index because `UNIQUE(channel, timestamp)` already creates an equivalent SQLite auto-index.

## Estimated performance impact
Synthetic in-memory SQLite benchmark using 120k messages, 30k posted links, 80 channels, and 700 users:

| Query shape | Before | After | Estimate |
| --- | ---: | ---: | ---: |
| Thread load by `timestamp OR thread_ts` | 3.690ms | 0.001ms | ~2768x faster |
| Opt-out message rewrite by `user` | 2.415ms | 0.132ms | ~18x faster |
| Duplicate-link recency lookup | 0.005ms | 0.001ms | ~4x faster |
| Embedded rows ordered by timestamp, capped | 4.546ms | 0.014ms | ~332x faster |
| Member channel lookup | 0.113ms | 0.010ms | ~11x faster |

Real production gains depend on database size, cache warmth, row distribution, and disk IO. The main expected benefit is avoiding full scans on large archive tables; write cost increases slightly because each message insert updates additional indexes.

## Validation
- `uv run pytest tests` -> 46 passed
- `uv run python -m py_compile utils.py tests/test_utils.py`
- `git diff --check`

Base branch was refreshed with `git fetch origin master` before branch creation and again before push/PR creation; this PR targets current `master`.
