### PR TITLE
Add CI gates for uv tests and Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: Verify lockfile
+        run: uv lock --check
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run tests
+        run: uv run pytest tests
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            PY_BUILD_VERS=3.11

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,12 +4,8 @@ on:
   schedule:
     - cron: '45 15 * * *'
   push:
-    # branches: [ master ]
-    branches: [ '*' ]
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
-  pull_request:
     branches: [ master ]
+    tags: [ 'v*.*.*' ]
 
 env:
   PY_BUILD_VERS: 3.11 # Change on need.
@@ -27,47 +23,36 @@ jobs:
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
-      id-token: write
 
     steps:
-      -
-        name: Checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      -
-        name: Setup Docker buildx
-        # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
 
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             PY_BUILD_VERS=${{ env.PY_BUILD_VERS }}


### PR DESCRIPTION
## Summary
- add a CI workflow that checks the uv lockfile, installs locked dependencies, and runs the focused test suite
- keep PR container validation by building the Docker image without pushing
- narrow image publication to master, semver tags, and the existing schedule while adding Buildx GHA cache

## Validation
- UV_CACHE_DIR=/private/tmp/slack-archive-bot-ci-uv-cache uv lock --check
- UV_CACHE_DIR=/private/tmp/slack-archive-bot-ci-uv-cache uv sync --frozen
- UV_CACHE_DIR=/private/tmp/slack-archive-bot-ci-uv-cache uv run pytest tests
- UV_CACHE_DIR=/private/tmp/slack-archive-bot-ci-uv-cache uv run python -c "from pathlib import Path; import yaml; [yaml.safe_load(Path(p).read_text()) for p in ['.github/workflows/ci.yml', '.github/workflows/docker-publish.yml']]; print('workflow yaml ok')"
- git diff --check