### PR TITLE
fix: prevent duplicate xcancel alerts from concurrent message events

### DIFF
--- a/archivebot.py
+++ b/archivebot.py
@@ -11,7 +11,7 @@ from slack_bolt import App
 from openai import OpenAI
 
 from ai_context import format_messages_for_prompt, get_ai_context_scope, is_engage_request
-from utils import db_connect, migrate_db
+from utils import claim_xcancel_alert, db_connect, finalize_xcancel_alert, migrate_db
 from url_cleaner import UrlCleaner
 from xcancel import build_xcancel_response_text
 from sferait_context import (
@@ -586,6 +586,9 @@ def delete_xcancel_alert(parent_ts, channel=None):
         alerts = cursor.fetchall()
 
         for alert_ts, alert_channel in alerts:
+            if not alert_ts:
+                # Riserva senza messaggio ancora postato: nulla da cancellare su Slack.
+                continue
             try:
                 app.client.chat_delete(channel=alert_channel, ts=alert_ts)
                 deleted_any = True
@@ -636,6 +639,75 @@ def get_xcancel_alert_text(parent_ts, channel):
         conn.close()
 
 
+def claim_xcancel_alert_slot(parent_ts, channel, alert_text):
+    """Riserva lo slot dell'alert xcancel.
+
+    Returns:
+        True se la riserva è acquisita, False se un altro handler l'ha già
+        presa, None se la riserva è fallita per un errore DB.
+    """
+    if not parent_ts or not channel:
+        return False
+
+    conn, cursor = db_connect(database_path)
+    try:
+        claimed = claim_xcancel_alert(cursor, parent_ts, channel, alert_text)
+        conn.commit()
+        return claimed
+    except Exception as e:
+        logger.error(f"Error claiming xcancel alert slot: {e}")
+        conn.rollback()
+        return None
+    finally:
+        conn.close()
+
+
+def finalize_xcancel_alert_claim(parent_ts, alert_ts, channel, alert_text):
+    """Completa la riserva con il ts dell'alert postato.
+
+    Returns:
+        True se la riserva era ancora presente, False se è stata rimossa o
+        sostituita nel frattempo (parent cancellato o testo modificato).
+    """
+    conn, cursor = db_connect(database_path)
+    try:
+        finalized = finalize_xcancel_alert(cursor, parent_ts, alert_ts, channel, alert_text)
+        conn.commit()
+        return finalized
+    except Exception as e:
+        logger.error(f"Error finalizing xcancel alert claim: {e}")
+        conn.rollback()
+        # In dubbio meglio tenere l'alert postato che cancellarlo per un
+        # errore di bookkeeping.
+        return True
+    finally:
+        conn.close()
+
+
+def release_xcancel_alert_claim(parent_ts, channel, alert_text):
+    """Rilascia la riserva dell'alert xcancel se il post su Slack non è riuscito.
+
+    Rimuove solo la riserva con lo stesso testo, per non toccare una riserva
+    più recente acquisita nel frattempo da un altro handler.
+    """
+    conn, cursor = db_connect(database_path)
+    try:
+        cursor.execute(
+            """
+            DELETE FROM xcancel_alerts
+            WHERE parent_message_ts = ? AND channel = ?
+              AND alert_message_ts = '' AND alert_text = ?
+            """,
+            (parent_ts, channel, alert_text),
+        )
+        conn.commit()
+    except Exception as e:
+        logger.error(f"Error releasing xcancel alert claim: {e}")
+        conn.rollback()
+    finally:
+        conn.close()
+
+
 def post_xcancel_alternatives(message, say):
     """Se il messaggio contiene link a x.com, posta le alternative xcancel.com nel thread."""
     response_text = build_xcancel_response_text(message.get("text", ""))
@@ -643,14 +715,51 @@ def post_xcancel_alternatives(message, say):
         return
 
     parent_ts = message.get("ts")
-    thread_ts = message.get("thread_ts", message.get("ts"))
+    channel = message.get("channel")
+    thread_ts = message.get("thread_ts", parent_ts)
+
+    # L'evento message e il message_changed generato dall'unfurl del link (o un
+    # retry di Slack) possono processare lo stesso messaggio in parallelo: solo
+    # chi riserva lo slot posta l'alert, gli altri escono senza duplicare.
+    claimed = claim_xcancel_alert_slot(parent_ts, channel, response_text)
+    if claimed is False:
+        logger.debug(
+            f"XCANCEL_ALERT_ALREADY_CLAIMED: parent_ts={parent_ts} channel={channel}"
+        )
+        return
+    if claimed is None:
+        # Riserva fallita per errore DB: meglio rischiare un raro duplicato
+        # che sopprimere l'alert in silenzio.
+        logger.warning(
+            f"XCANCEL_CLAIM_FAILED: posting without claim, parent_ts={parent_ts} channel={channel}"
+        )
+
     try:
         result = say(text=response_text, thread_ts=thread_ts)
         alert_ts = result.get("ts") if result else None
-        if alert_ts:
-            save_xcancel_alert(parent_ts, alert_ts, message.get("channel"), response_text)
+        if not alert_ts:
+            if claimed:
+                release_xcancel_alert_claim(parent_ts, channel, response_text)
+            return
+
+        if claimed:
+            if not finalize_xcancel_alert_claim(parent_ts, alert_ts, channel, response_text):
+                # Il parent è stato cancellato (o il testo modificato) mentre
+                # postavamo: l'alert appena creato non serve più.
+                try:
+                    app.client.chat_delete(channel=channel, ts=alert_ts)
+                    logger.info(
+                        f"XCANCEL_ALERT_SUPERSEDED: removed stale alert {alert_ts} in {channel}"
+                    )
+                except Exception as e:
+                    logger.warning(f"Could not delete stale xcancel alert {alert_ts}: {e}")
+                return
+        else:
+            save_xcancel_alert(parent_ts, alert_ts, channel, response_text)
         logger.info("Posted xcancel alternatives")
     except Exception as e:
+        if claimed:
+            release_xcancel_alert_claim(parent_ts, channel, response_text)
         logger.error(f"Error posting xcancel alternative: {e}")
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
-from utils import migrate_db
+from utils import claim_xcancel_alert, finalize_xcancel_alert, migrate_db
 
 
 def test_migrate_db_creates_xcancel_alerts_table():
@@ -26,6 +26,105 @@ def test_migrate_db_creates_xcancel_alerts_table():
         "channel",
         "alert_text",
     }
+
+
+def test_claim_xcancel_alert_only_first_claim_wins():
+    conn = sqlite3.connect(":memory:")
+    cursor = conn.cursor()
+    migrate_db(conn, cursor)
+
+    assert claim_xcancel_alert(cursor, "1710000000.000100", "C123", "alert") is True
+    # Un secondo claim per lo stesso messaggio (evento message vs message_changed
+    # dell'unfurl, o retry di Slack) non deve vincere.
+    assert claim_xcancel_alert(cursor, "1710000000.000100", "C123", "alert") is False
+
+
+def test_claim_xcancel_alert_is_scoped_per_message_and_channel():
+    conn = sqlite3.connect(":memory:")
+    cursor = conn.cursor()
+    migrate_db(conn, cursor)
+
+    assert claim_xcancel_alert(cursor, "1710000000.000100", "C123", "alert") is True
+    assert claim_xcancel_alert(cursor, "1710000000.000100", "C456", "alert") is True
+    assert claim_xcancel_alert(cursor, "1710000000.000200", "C123", "alert") is True
+
+
+def test_claim_xcancel_alert_can_be_reclaimed_after_delete():
+    conn = sqlite3.connect(":memory:")
+    cursor = conn.cursor()
+    migrate_db(conn, cursor)
+
+    assert claim_xcancel_alert(cursor, "1710000000.000100", "C123", "alert") is True
+    cursor.execute(
+        "DELETE FROM xcancel_alerts WHERE parent_message_ts = ? AND channel = ?",
+        ("1710000000.000100", "C123"),
+    )
+    assert claim_xcancel_alert(cursor, "1710000000.000100", "C123", "alert") is True
+
+
+def test_finalize_xcancel_alert_updates_claimed_slot():
+    conn = sqlite3.connect(":memory:")
+    cursor = conn.cursor()
+    migrate_db(conn, cursor)
+
+    claim_xcancel_alert(cursor, "1710000000.000100", "C123", "alert")
+
+    assert finalize_xcancel_alert(
+        cursor, "1710000000.000100", "1710000001.000500", "C123", "alert"
+    ) is True
+    row = cursor.execute(
+        "SELECT alert_message_ts FROM xcancel_alerts WHERE parent_message_ts = ?",
+        ("1710000000.000100",),
+    ).fetchone()
+    assert row == ("1710000001.000500",)
+
+
+def test_finalize_xcancel_alert_fails_if_claim_was_removed():
+    conn = sqlite3.connect(":memory:")
+    cursor = conn.cursor()
+    migrate_db(conn, cursor)
+
+    claim_xcancel_alert(cursor, "1710000000.000100", "C123", "alert")
+    # Il messaggio parent viene cancellato mentre il post dell'alert è in corso.
+    cursor.execute("DELETE FROM xcancel_alerts")
+
+    assert finalize_xcancel_alert(
+        cursor, "1710000000.000100", "1710000001.000500", "C123", "alert"
+    ) is False
+
+
+def test_finalize_xcancel_alert_fails_if_claim_was_replaced():
+    conn = sqlite3.connect(":memory:")
+    cursor = conn.cursor()
+    migrate_db(conn, cursor)
+
+    claim_xcancel_alert(cursor, "1710000000.000100", "C123", "old alert")
+    # Il testo del messaggio è cambiato durante il post: la riserva è stata
+    # sostituita da sync_xcancel_alternatives_for_message con un nuovo testo.
+    cursor.execute("DELETE FROM xcancel_alerts")
+    claim_xcancel_alert(cursor, "1710000000.000100", "C123", "new alert")
+
+    assert finalize_xcancel_alert(
+        cursor, "1710000000.000100", "1710000001.000500", "C123", "old alert"
+    ) is False
+    # La riserva nuova non deve essere stata toccata.
+    row = cursor.execute("SELECT alert_message_ts, alert_text FROM xcancel_alerts").fetchone()
+    assert row == ("", "new alert")
+
+
+def test_finalize_xcancel_alert_does_not_overwrite_completed_alert():
+    conn = sqlite3.connect(":memory:")
+    cursor = conn.cursor()
+    migrate_db(conn, cursor)
+
+    claim_xcancel_alert(cursor, "1710000000.000100", "C123", "alert")
+    finalize_xcancel_alert(
+        cursor, "1710000000.000100", "1710000001.000500", "C123", "alert"
+    )
+
+    assert finalize_xcancel_alert(
+        cursor, "1710000000.000100", "1710000002.000900", "C123", "alert"
+    ) is False
 
 
 def test_migrate_db_creates_hot_path_indexes():

--- a/utils.py
+++ b/utils.py
@@ -506,6 +506,63 @@ def migrate_db(conn, cursor):
 
 
 
+def claim_xcancel_alert(cursor, parent_ts, channel, alert_text):
+    """Riserva atomicamente lo slot dell'alert xcancel per (parent_ts, channel).
+
+    Sfrutta la PRIMARY KEY (parent_message_ts, channel) con INSERT OR IGNORE:
+    solo il primo handler che processa il messaggio (evento message, message_changed
+    dell'unfurl o retry di Slack) acquisisce lo slot e deve postare l'alert.
+
+    Args:
+        cursor: Cursore SQLite su un DB già migrato.
+        parent_ts: Timestamp del messaggio che contiene i link x.com.
+        channel: Canale del messaggio.
+        alert_text: Testo dell'alert che verrà postato.
+
+    Returns:
+        bool: True se lo slot è stato riservato da questa chiamata, False se
+        un alert per lo stesso messaggio è già tracciato o in corso di post.
+    """
+    cursor.execute(
+        """
+        INSERT OR IGNORE INTO xcancel_alerts
+        (parent_message_ts, alert_message_ts, channel, alert_text)
+        VALUES (?, '', ?, ?)
+        """,
+        (parent_ts, channel, alert_text),
+    )
+    return cursor.rowcount == 1
+
+
+def finalize_xcancel_alert(cursor, parent_ts, alert_ts, channel, alert_text):
+    """Completa la riserva dell'alert xcancel con il ts del messaggio postato.
+
+    Aggiorna solo la riserva originale (alert_message_ts vuoto e stesso testo):
+    se nel frattempo la riserva è stata rimossa o sostituita (parent cancellato
+    o testo modificato durante il post), non tocca nulla.
+
+    Args:
+        cursor: Cursore SQLite su un DB già migrato.
+        parent_ts: Timestamp del messaggio che contiene i link x.com.
+        alert_ts: Timestamp dell'alert appena postato su Slack.
+        channel: Canale del messaggio.
+        alert_text: Testo con cui era stata acquisita la riserva.
+
+    Returns:
+        bool: True se la riserva è stata completata, False se non esiste più.
+    """
+    cursor.execute(
+        """
+        UPDATE xcancel_alerts
+        SET alert_message_ts = ?
+        WHERE parent_message_ts = ? AND channel = ?
+          AND alert_message_ts = '' AND alert_text = ?
+        """,
+        (alert_ts, parent_ts, channel, alert_text),
+    )
+    return cursor.rowcount == 1
+
+
 def db_connect(database_path):
     conn = sqlite3.connect(database_path)
     cursor = conn.cursor()


### PR DESCRIPTION
## What

- Add atomic claim/finalize primitives (`claim_xcancel_alert`, `finalize_xcancel_alert`) in `utils.py`, backed by the existing `PRIMARY KEY (parent_message_ts, channel)` on `xcancel_alerts` via `INSERT OR IGNORE`.
- `post_xcancel_alternatives` now posts only after winning the claim; the losing handler skips silently instead of posting a second alert.
- If the claim is invalidated mid-post (parent message deleted or edited while `say()` is in flight), the freshly posted alert is removed from Slack instead of being left orphaned.
- If the claim fails for a DB error, the alert is still posted (untracked) rather than silently suppressed; `delete_xcancel_alert` skips Slack deletion for claim placeholder rows.
- Unit tests for both primitives (first-claim-wins, scoping, reclaim, superseded/removed claims).

## Why

xcancel alternatives were posted **twice** for the same x.com link. When a message with an x.com link is posted, Slack sends two events: the `message` event and, ~1s later, a `message_changed` event generated by the link unfurl (same text, new attachments). `handle_message` does slow work (embeddings, permalink API, link checks) before posting the alert, so `sync_xcancel_alternatives_for_message` (triggered by the unfurl event) found no tracked alert in the DB and posted one itself; the original handler then posted a second one. With multiple gunicorn workers and Bolt's listener thread pool, the two events genuinely run in parallel, and `INSERT OR REPLACE` masked the duplicate in the DB (the first alert became untracked). The same non-atomic check-then-post also duplicated alerts on Slack event retries.

## How to test

- `uv run pytest tests/ -v` (53 passed)
- Manually: post a message containing an `https://x.com/...` link in a channel the bot is in; exactly one "Link senza Shitler" reply should appear, including when the link unfurls. Edit the message to change the link: the old alert is replaced by one alert. Delete the message: the alert is removed.

## References

- Introduced by b447939 (Track and delete xcancel alerts) which added the `message_changed` sync path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)